### PR TITLE
Fix live-server path

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "build": "sass src/styles.scss src/styles.css",
-    "start": "live-server --port 8181"
+    "start": "live-server src --port=8181"
   },
   "devDependencies": {
     "live-server": "^1.2.2",


### PR DESCRIPTION
## Summary
- serve files from `src` directory in npm start script
- use live-server with explicit port flag

## Testing
- `npm run build`
- `npm start` (terminated immediately after launch)

------
https://chatgpt.com/codex/tasks/task_e_6858804979b08333830d5cb71b600c43