### PR TITLE
Add intro screen and sin-based progression

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,12 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body class="fullscreen">
-  <div class="game-board">
+  <div id="intro-screen" class="intro-screen">
+    <h1>Arcana Abismal</h1>
+    <button id="play-btn">Jugar</button>
+  </div>
+
+  <div class="game-board hidden">
     <div class="deck deck--left">
       <div class="card-back"></div>
       <span class="deck-count discard-count">0</span>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -3,6 +3,24 @@ body {
 	padding: 0;
 }
 
+.hidden {
+  display: none;
+}
+
+.intro-screen {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0,0,0,0.8);
+  color: #fff;
+  gap: 1rem;
+  font: bold 24px sans-serif;
+  z-index: 1000;
+}
+
 /* Contenedor principal para el fondo (puede ser body o un div.fullscreen) */
 .fullscreen {
   position: relative;


### PR DESCRIPTION
## Summary
- add intro overlay with Play button
- enable progression through seven sins with random curses and simple narrative events
- display current sin in scoreboard
- style intro screen and hidden class

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859527407bc8333b8b34605a71a1aac