### PR TITLE
Actualiza lógica de pecados y marcador

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -28,9 +28,12 @@
     </div>
 
     <div class="scoreboard">
-      <span class="score-current">0</span>
-      <span class="score-separator">/</span>
-      <span class="score-goal">0</span>
+      <span class="score-sin">Pecado</span>
+      <div class="score-progress">
+        <span class="score-current">0</span>
+        <span class="score-separator">-</span>
+        <span class="score-goal">0</span>
+      </div>
       <span class="score-coins"><span>0</span> <img src="assets/images/coin.png" alt="Coins"/></span>
     </div>
 

--- a/src/script.js
+++ b/src/script.js
@@ -424,6 +424,9 @@ class RoguelikeCardGame {
                         "Pereza"
                 ];
                 this.sinIndex = 0;
+                // objetivos necesarios para el primer pecado y aumento por nivel
+                this.baseObjectives = 4;
+                this.incrementObjectives = 2;
         }
 
 	initDeck() {
@@ -442,14 +445,15 @@ class RoguelikeCardGame {
 		this.hand = [];
 	}
 
-	initObjectives() {
-		this.objectivesDeck = shuffle([...objectives]);
-		this.activeObjectives = this.objectivesDeck.splice(0, this.objectivesCount);
-		this.currentLevel = 1;
-		this.completedThisLevel = 0;
-		this.toComplete = this.currentLevel;
-		this.gold = 0;
-	}
+        initObjectives() {
+                this.objectivesDeck = shuffle([...objectives]);
+                this.activeObjectives = this.objectivesDeck.splice(0, this.objectivesCount);
+                this.currentLevel = 1;
+                this.completedThisLevel = 0;
+                // número de objetivos a completar para el primer pecado
+                this.toComplete = this.baseObjectives;
+                this.gold = 0;
+        }
 
         startRun() {
                 this.initDeck();
@@ -564,7 +568,8 @@ class RoguelikeCardGame {
         nextLevel() {
                 this.currentLevel++;
                 this.sinIndex++;
-                this.toComplete = this.currentLevel;
+                // cada nuevo pecado requiere dos objetivos más
+                this.toComplete += this.incrementObjectives;
                 this.completedThisLevel = 0;
                 if (this.sinIndex >= this.sins.length) {
                         alert("Has derrotado todos los pecados. ¡Victoria!");
@@ -605,6 +610,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const objContainer = document.querySelector(".objectives");
         const tableContainer = document.querySelector(".table");
         const handContainer = document.querySelector(".hand");
+        const scoreSin = document.querySelector(".score-sin");
         const scoreCur = document.querySelector(".score-current");
         const scoreGoal = document.querySelector(".score-goal");
         const scoreCoins = document.querySelector(".score-coins > span");
@@ -615,13 +621,14 @@ document.addEventListener("DOMContentLoaded", () => {
         const board = document.querySelector(".game-board");
         let selectedHandIdx = null;
 
-	function render() {
-		// marcador
-                scoreCur.textContent = `${game.currentLevel} - ${game.sins[game.sinIndex]}`;
-		scoreGoal.textContent = game.toComplete;
-		scoreCoins.textContent = `${game.gold}`;
-		discardCount.textContent = game.discard.length;
-		drawCount.textContent = game.deck.length;
+        function render() {
+                // marcador
+                scoreSin.textContent = game.sins[game.sinIndex];
+                scoreCur.textContent = game.completedThisLevel;
+                scoreGoal.textContent = game.toComplete;
+                scoreCoins.textContent = `${game.gold}`;
+                discardCount.textContent = game.discard.length;
+                drawCount.textContent = game.deck.length;
 
 		// misiones
 		objContainer.innerHTML = "";

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -301,12 +301,26 @@ $gutter: 50px;
                 image-rendering: pixelated;
                 font: bold 16px monospace;
 
-		.score-current,
-		.score-separator,
-		.score-goal {
-			display: inline-block;
-			min-width: 24px;
-		}
+                .score-sin {
+                        display: block;
+                        font-size: 32px;
+                        margin-bottom: 4px;
+                        text-transform: uppercase;
+                }
+
+                .score-progress {
+                        display: flex;
+                        justify-content: center;
+                        gap: 4px;
+                        margin-bottom: 4px;
+                }
+
+                .score-current,
+                .score-separator,
+                .score-goal {
+                        display: inline-block;
+                        min-width: 24px;
+                }
 		.score-coins {
 			display: flex;
       font-size: 64px;


### PR DESCRIPTION
## Summary
- introduce `baseObjectives` y `incrementObjectives`
- inicia la partida con 4 objetivos y aumenta 2 por cada pecado vencido
- muestra el nombre del pecado actual y el progreso de objetivos en el HUD
- ajusta estilos para el nuevo marcador

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6860216c949483339fa4707368702627