### PR TITLE
Add dealing animations for level transition

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -122,6 +122,8 @@ body {
         color: #fff;
         gap: 1rem;
         z-index: 1000;
+        background: rgba(0, 0, 0, 0.8) url('assets/images/texture_noise.png');
+        background-size: cover;
 
         h2 {
                 font-family: 'Cinzel', serif;


### PR DESCRIPTION
## Summary
- style transition screen with noise background
- animate dealing of table, hand and objectives when resuming a level
- animate deck counter decrease during dealing

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686028d7ac6c8333984b77a1977703aa